### PR TITLE
A bit of parquet-refactoring progress

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -39,11 +39,7 @@ class ArrowEngine(Engine):
         # We would like to resolve these to the correct dataframe names
         # as soon as possible.
 
-        dataset = pq.ParquetDataset(
-            paths,
-            filesystem=get_pyarrow_filesystem(fs),
-            open_file_func=lambda fn: pq.ParquetFile(fs.open(fn, mode="rb"))
-        )
+        dataset = pq.ParquetDataset(paths, filesystem=get_pyarrow_filesystem(fs))
 
         if dataset.partitions is not None:
             partitions = [

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -39,7 +39,11 @@ class ArrowEngine(Engine):
         # We would like to resolve these to the correct dataframe names
         # as soon as possible.
 
-        dataset = pq.ParquetDataset(paths, filesystem=get_pyarrow_filesystem(fs))
+        dataset = pq.ParquetDataset(
+            paths,
+            filesystem=get_pyarrow_filesystem(fs),
+            open_file_func=lambda fn: pq.ParquetFile(fs.open(fn, mode="rb"))
+        )
 
         if dataset.partitions is not None:
             partitions = [

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -30,7 +30,7 @@ class ArrowEngine(Engine):
 
     @staticmethod
     def read_metadata(
-        fs, fs_token, paths, categories=None, index=None, gather_statistics=None
+        fs, paths, categories=None, index=None, gather_statistics=None
     ):
 
         # In pyarrow, the physical storage field names may differ from
@@ -79,6 +79,9 @@ class ArrowEngine(Engine):
 
         meta = _meta_from_dtypes(all_columns, dtypes)
         meta = clear_known_categories(meta, cols=categories)
+
+        if gather_statistics is None and dataset.metadata:
+            gather_statistics = True
 
         if gather_statistics and pieces:
             # Read from _metadata file
@@ -144,7 +147,7 @@ class ArrowEngine(Engine):
         )
 
     @staticmethod
-    def write(df, fs, fs_token, path, append=False, partition_on=None, **kwargs):
+    def write(df, fs, path, append=False, partition_on=None, **kwargs):
         if append:
             try:
                 dataset = pq.ParquetDataset(path, filesystem=get_pyarrow_filesystem(fs))

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -188,7 +188,7 @@ def read_parquet(
             columns = [columns]
 
         if sanitize_cols:
-            columns = [ col for col in columns if col not in index]
+            columns = [col for col in columns if col not in index]
         if set(index).intersection(columns):
             raise ValueError("Specified index and column names must not "
                              "intersect")
@@ -211,7 +211,6 @@ def read_parquet(
         )
         for i, part in enumerate(parts)
     }
-
     if index:
         meta = meta.set_index(index)
 

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -28,6 +28,7 @@ def read_parquet(
     storage_options=None,
     engine="auto",
     gather_statistics=True,
+    infer_divisions=False,
 ):
     """
     Read ParquetFile into a Dask DataFrame

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -81,7 +81,7 @@ class FastParquetEngine(Engine):
 
     @staticmethod
     def read_metadata(
-        fs, fs_token, paths, categories=None, index=None, gather_statistics=None
+        fs, paths, categories=None, index=None, gather_statistics=None
     ):
         """
 

--- a/dask/dataframe/io/parquet/utils.py
+++ b/dask/dataframe/io/parquet/utils.py
@@ -218,6 +218,9 @@ def _parse_pandas_metadata(pandas_metadata):
         # 2. Those versions did not allow for duplicate index / column names
         # So we know that if a name is in index_storage_names, it must be an
         # index name
+        if index_storage_names and isinstance(index_storage_names[0], dict):
+            # Cannot handle dictionary case
+            index_storage_names = []
         index_names = list(index_storage_names)  # make a copy
         index_storage_names2 = set(index_storage_names)
         column_names = [

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -17,8 +17,7 @@ from dask.dataframe.io.parquet.utils import _parse_pandas_metadata
 from dask.utils import natural_sort_key
 
 try:
-    #import fastparquet
-    fastparquet = False
+    import fastparquet
 except ImportError:
     fastparquet = False
 
@@ -1389,5 +1388,5 @@ def test_datasets_timeseries(tmp_path):
     df.to_parquet(tmp_path)
 
     df2 = dd.read_parquet(tmp_path)
-
+    # Fails. Need compute to translate int to timestamp
     assert_eq(df, df2)

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1006,12 +1006,11 @@ def test_writing_parquet_with_compression(tmpdir, compression, engine):
 
     df = pd.DataFrame({'x': ['a', 'b', 'c'] * 10,
                        'y': [1, 2, 3] * 10})
+    df.index.name = 'index'
     ddf = dd.from_pandas(df, npartitions=3)
 
     ddf.to_parquet(fn, compression=compression, engine=engine)
     out = dd.read_parquet(fn, engine=engine)
-    out.index.name = None
-
     assert_eq(out, ddf)
 
 
@@ -1333,13 +1332,13 @@ def test_append_cat_fp(tmpdir):
 
 def test_passing_parquetfile(tmpdir):
     import shutil
-    fp = pytest.importorskip('fastparquet')
+    check_fastparquet()
     path = str(tmpdir)
     df = pd.DataFrame({"x": [1, 3, 2, 4]})
     ddf = dd.from_pandas(df, npartitions=1)
 
     dd.to_parquet(ddf, path)
-    pf = fp.ParquetFile(path)
+    pf = fastparquet.ParquetFile(path)
     shutil.rmtree(path)
 
     # should pass, because no need to re-read metadata
@@ -1388,5 +1387,5 @@ def test_datasets_timeseries(tmp_path):
     df.to_parquet(tmp_path)
 
     df2 = dd.read_parquet(tmp_path)
-    # Fails. Need compute to translate int to timestamp
+    # Need compute to get correct timestamp here
     assert_eq(df, df2)

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -21,49 +21,17 @@ try:
 except ImportError:
     fastparquet = False
 
-
-try:
-    import pyarrow as pa
-    check_pa_divs = pa.__version__ >= LooseVersion('0.9.0')
-except ImportError:
-    check_pa_divs = False
-
-
 try:
     import pyarrow.parquet as pq
 except ImportError:
     pq = False
 
 
-SKIP_FASTPARQUET = not fastparquet
-SKIP_FASTPARQUET_REASON = 'fastparquet not found'
-FASTPARQUET_MARK = pytest.mark.skipif(SKIP_FASTPARQUET, reason=SKIP_FASTPARQUET_REASON)
-
-if pq and pa.__version__ == LooseVersion('0.13.0'):
-    SKIP_PYARROW = True
-    SKIP_PYARROW_REASON = 'pyarrow 0.13.0 not supported'
-else:
-    SKIP_PYARROW = not pq
-    SKIP_PYARROW_REASON = 'pyarrow not found'
-PYARROW_MARK = pytest.mark.skipif(SKIP_PYARROW, reason=SKIP_PYARROW_REASON)
-
-
-def check_fastparquet():
-    if SKIP_FASTPARQUET:
-        pytest.skip(SKIP_FASTPARQUET_REASON)
-
-
-def check_pyarrow():
-    if SKIP_PYARROW:
-        pytest.skip(SKIP_PYARROW_REASON)
-
-
-def should_check_divs(engine):
-    if engine == 'fastparquet':
-        return True
-    elif engine == 'pyarrow' and check_pa_divs:
-        return True
-    return False
+try:
+    import pyarrow as pa
+    check_pa_divs = pa.__version__ >= LooseVersion('0.9.0')
+except ImportError:
+    check_pa_divs = False
 
 
 nrows = 40
@@ -77,10 +45,20 @@ ddf = dd.from_pandas(df, npartitions=npartitions)
 
 
 @pytest.fixture(params=[
-    pytest.param('fastparquet', marks=FASTPARQUET_MARK),
-    pytest.param('pyarrow', marks=PYARROW_MARK)])
+    # pytest.param('fastparquet', marks=pytest.mark.skipif(not fastparquet, reason='fastparquet not found')),
+    pytest.param('pyarrow', marks=pytest.mark.skipif(not pq, reason='pyarrow not found'))])
 def engine(request):
     return request.param
+
+
+def check_fastparquet():
+    if not fastparquet:
+        pytest.skip('fastparquet not found')
+
+
+def check_pyarrow():
+    if not pq:
+        pytest.skip('pyarrow not found')
 
 
 def write_read_engines(**kwargs):
@@ -91,10 +69,9 @@ def write_read_engines(**kwargs):
     marks = {(w, r): [] for w in backends for r in backends}
 
     # Skip if uninstalled
-    for name, skip, reason in [('fastparquet', SKIP_FASTPARQUET, SKIP_FASTPARQUET_REASON),
-                               ('pyarrow', SKIP_PYARROW, SKIP_PYARROW_REASON)]:
-        if skip:
-            val = pytest.mark.skip(reason=reason)
+    for name, exists in [('fastparquet', fastparquet), ('pyarrow', pq)]:
+        val = pytest.mark.skip(reason='%s not found' % name)
+        if not exists:
             for k in marks:
                 if name in k:
                     marks[k].append(val)
@@ -157,10 +134,7 @@ def test_empty(tmpdir, write_engine, read_engine, index):
     ddf = dd.from_pandas(df, npartitions=2)
 
     ddf.to_parquet(fn, write_index=index, engine=write_engine)
-    if index:
-        read_df = dd.read_parquet(fn, index='a', engine=read_engine)
-    else:
-        read_df = dd.read_parquet(fn, engine=read_engine)
+    read_df = dd.read_parquet(fn, engine=read_engine)
     assert_eq(ddf, read_df)
 
 
@@ -204,18 +178,27 @@ def test_read_list(tmpdir, write_engine, read_engine):
 @write_read_engines_xfail
 def test_columns_index(tmpdir, write_engine, read_engine):
     fn = str(tmpdir)
-    ddf.to_parquet(fn, write_index=True, engine=write_engine)
+    ddf.to_parquet(fn, engine=write_engine)
 
     # With Index
     # ----------
     # ### Emtpy columns ###
     # With divisions if supported
-    assert_eq(dd.read_parquet(fn, columns=[], index='myindex', engine=read_engine),
+    assert_eq(dd.read_parquet(fn, columns=[], engine=read_engine, index='myindex'),
               ddf[[]])
 
     # No divisions
-    assert_eq(dd.read_parquet(fn, columns=[], index='myindex', engine=read_engine,
-               gather_statistics=False), ddf[[]].clear_divisions(), check_divisions=True)
+    assert_eq(dd.read_parquet(fn, columns=[], engine=read_engine, gather_statistics=False),
+              ddf[[]].clear_divisions(), check_divisions=True)
+
+    # ### Single column, auto select index ###
+    # With divisions if supported
+    assert_eq(dd.read_parquet(fn, columns=['x'], engine=read_engine),
+              ddf[['x']])
+
+    # No divisions
+    assert_eq(dd.read_parquet(fn, columns=['x'], engine=read_engine, gather_statistics=False),
+              ddf[['x']].clear_divisions(), check_divisions=True)
 
     # ### Single column, specify index ###
     # With divisions if supported
@@ -256,7 +239,7 @@ def test_columns_no_index(tmpdir, write_engine, read_engine):
     # No Index
     # --------
     # All columns, none as index
-    assert_eq(dd.read_parquet(fn, index=False, engine=read_engine),
+    assert_eq(dd.read_parquet(fn, index=False, engine=read_engine, gather_statistics=False),
               ddf2, check_index=False, check_divisions=True)
 
     # Two columns, none as index
@@ -271,25 +254,7 @@ def test_columns_no_index(tmpdir, write_engine, read_engine):
 
 
 @write_read_engines_xfail
-def test_infer_divisions_not_sorted(tmpdir, write_engine, read_engine):
-    fn = str(tmpdir)
-    ddf.to_parquet(fn, engine=write_engine)
-
-    if read_engine == 'pyarrow' and not check_pa_divs:
-        match = 'requires pyarrow >=0.9.0'
-        ex = NotImplementedError
-    else:
-        match = 'not known to be sorted across partitions'
-        ex = ValueError
-
-    with pytest.raises(ex, match=match):
-        dd.read_parquet(fn, index='x', engine=read_engine, infer_divisions=True)
-
-
-@write_read_engines_xfail
-def test_infer_divisions_no_index(tmpdir, write_engine, read_engine):
-    if read_engine == 'pyarrow' and pa.__version__ >= LooseVersion('0.13.0'):
-        pytest.skip("No longer an error from pyarrow 0.13.0")
+def test_gather_statistics_no_index(tmpdir, write_engine, read_engine):
     fn = str(tmpdir)
     ddf.to_parquet(fn, engine=write_engine, write_index=False)
 
@@ -1008,7 +973,8 @@ def test_columns_name(tmp_path, engine):
 @pytest.mark.parametrize('compression,', ['default', None, 'gzip', 'snappy'])
 def test_writing_parquet_with_compression(tmpdir, compression, engine):
     fn = str(tmpdir)
-    if engine == 'fastparquet' and compression in ['snappy', 'default']:
+
+    if compression in ['snappy', 'default']:
         pytest.importorskip('snappy')
 
     df = pd.DataFrame({'x': ['a', 'b', 'c'] * 10,
@@ -1018,10 +984,7 @@ def test_writing_parquet_with_compression(tmpdir, compression, engine):
     ddf.to_parquet(fn, compression=compression, engine=engine)
     out = dd.read_parquet(fn, engine=engine)
 
-    out = dd.read_parquet(fn, engine=engine,
-                          infer_divisions=should_check_divs(engine))
-    assert_eq(out, ddf, check_index=(engine != 'fastparquet'),
-              check_divisions=should_check_divs(engine))
+    assert_eq(out, ddf)
 
 
 @pytest.fixture(params=[
@@ -1146,7 +1109,8 @@ def test_parse_pandas_metadata_null_index():
 def test_read_no_metadata(tmpdir, engine):
     # use pyarrow.parquet to create a parquet file without
     # pandas metadata
-    check_pyarrow()
+    pa = pytest.importorskip("pyarrow")
+    import pyarrow.parquet as pq
     tmp = str(tmpdir) + "table.parq"
 
     table = pa.Table.from_arrays([pa.array([1, 2, 3]),
@@ -1294,23 +1258,9 @@ def test_select_partitioned_column(tmpdir, engine):
     df_partitioned[df_partitioned.fake_categorical1 == 'A'].compute()
 
 
-def test_with_tz(tmpdir, engine):
-    if engine == 'pyarrow' and pa.__version__ < LooseVersion('0.11.0'):
-        pytest.skip("pyarrow<0.11.0 did not support this")
-    if engine == 'fastparquet' and fastparquet.__version__ < LooseVersion(
-            '0.3.0'):
-        pytest.skip("fastparquet<0.3.0 did not support this")
-    fn = str(tmpdir)
-    df = pd.DataFrame([[0]], columns=['a'], dtype='datetime64[ns, UTC]')
-    df = dd.from_pandas(df, 1)
-    df.to_parquet(fn, engine=engine)
-    df2 = dd.read_parquet(fn, engine=engine)
-    assert_eq(df, df2, check_divisions=False, check_index=False)
-
-
 def test_arrow_partitioning(tmpdir):
     # Issue #3518
-    check_pyarrow()
+    pytest.importorskip('pyarrow')
     path = str(tmpdir)
     data = {
         'p': np.repeat(np.arange(3), 2).astype(np.int8),
@@ -1337,7 +1287,7 @@ def test_informative_error_messages():
 
 
 def test_append_cat_fp(tmpdir):
-    check_fastparquet()
+    pytest.importorskip('fastparquet')
     path = str(tmpdir)
     # https://github.com/dask/dask/issues/4120
     df = pd.DataFrame({"x": ["a", "a", "b", "a", "b"]})
@@ -1354,13 +1304,13 @@ def test_append_cat_fp(tmpdir):
 
 def test_passing_parquetfile(tmpdir):
     import shutil
-    check_fastparquet()
+    fp = pytest.importorskip('fastparquet')
     path = str(tmpdir)
     df = pd.DataFrame({"x": [1, 3, 2, 4]})
     ddf = dd.from_pandas(df, npartitions=1)
 
     dd.to_parquet(ddf, path)
-    pf = fastparquet.ParquetFile(path)
+    pf = fp.ParquetFile(path)
     shutil.rmtree(path)
 
     # should pass, because no need to re-read metadata
@@ -1380,8 +1330,7 @@ def test_passing_parquetfile(tmpdir):
     pytest.param(pd.DataFrame({'x': list(map(pd.Timestamp, [3000, 2000, 1000]))}),  # us
         marks=pytest.mark.xfail(reason="Need to use allow_truncated_timestampe keyword")),
     pd.DataFrame({'x': [3000, 2000, 1000]}).astype('M8[ns]'),
-    pytest.param(pd.DataFrame({'x': [3, 2, 1]}).astype('M8[ns]'),
-        marks=pytest.mark.xfail(reason="PyArrow will cast from ns -> us")),
+    pd.DataFrame({'x': [3, 2, 1]}).astype('M8[ns]'),
     pd.DataFrame({'x': [3, 2, 1]}).astype('M8[us]'),
     pd.DataFrame({'x': [3, 2, 1]}).astype('M8[ms]'),
     pd.DataFrame({'x': [3, 2, 1]}).astype('uint16'),

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -446,6 +446,7 @@ def test_categorical(tmpdir, write_engine, read_engine):
 
 def test_append(tmpdir, engine):
     """Test that appended parquet equal to the original one."""
+    check_fastparquet()
     tmp = str(tmpdir)
     df = pd.DataFrame({'i32': np.arange(1000, dtype=np.int32),
                        'i64': np.arange(1000, dtype=np.int64),
@@ -466,6 +467,7 @@ def test_append(tmpdir, engine):
 
 def test_append_create(tmp_path, engine):
     """Test that appended parquet equal to the original one."""
+    check_fastparquet()
     df = pd.DataFrame({'i32': np.arange(1000, dtype=np.int32),
                        'i64': np.arange(1000, dtype=np.int64),
                        'f': np.arange(1000, dtype=np.float64),
@@ -484,6 +486,7 @@ def test_append_create(tmp_path, engine):
 
 
 def test_append_with_partition(tmpdir, engine):
+    check_fastparquet()
     tmp = str(tmpdir)
     df0 = pd.DataFrame({'lat': np.arange(0, 10), 'lon': np.arange(10, 20),
                         'value': np.arange(100, 110)})
@@ -1314,6 +1317,7 @@ def test_informative_error_messages():
 
 def test_append_cat_fp(tmpdir):
     pytest.importorskip('fastparquet')
+    check_fastparquet()
     path = str(tmpdir)
     # https://github.com/dask/dask/issues/4120
     df = pd.DataFrame({"x": ["a", "a", "b", "a", "b"]})


### PR DESCRIPTION
Minor refactoring changes to leverage recent work in `arrow.parquet` (i.e. [ARROW-1983/PR#4405](https://github.com/wesm/arrow/commit/997226a9263430bc0422189180bc2551aed1f63d)).

Status: 91 tests passing, 36 failing (only 16 failing for `pyarrow` engine)

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
